### PR TITLE
PyTorchDemo app for current iOS

### DIFF
--- a/PyTorchDemo/Podfile
+++ b/PyTorchDemo/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '12.0'
+platform :ios, '14.3'
 target 'PyTorchDemo' do
-  pod 'LibTorch', '~>1.4.0'
+  pod 'LibTorch', '~>1.7.0'
 end

--- a/PyTorchDemo/PyTorchDemo/ImageClassification/ImagePredictor.swift
+++ b/PyTorchDemo/PyTorchDemo/ImageClassification/ImagePredictor.swift
@@ -3,7 +3,7 @@ import UIKit
 class ImagePredictor: Predictor {
     private var isRunning: Bool = false
     private lazy var module: VisionTorchModule = {
-        if let filePath = Bundle.main.path(forResource: "mobilenet_quantized", ofType: "pt"),
+        if let filePath = Bundle.main.path(forResource: "mobilenet", ofType: "pt"),
             let module = VisionTorchModule(fileAtPath: filePath) {
             return module
         } else {

--- a/PyTorchDemo/PyTorchDemo/TorchBridge/TorchModule.mm
+++ b/PyTorchDemo/PyTorchDemo/TorchBridge/TorchModule.mm
@@ -77,7 +77,7 @@
 
 - (NSArray<NSString*>*)topics {
   try {
-    auto genericList = _impl.run_method("get_classes").toGenericList();
+    auto genericList = _impl.run_method("get_classes").toList();
     NSMutableArray<NSString*>* topics = [NSMutableArray<NSString*> new];
     for (int i = 0; i < genericList.size(); i++) {
       std::string topic = genericList.get(i).toString()->string();


### PR DESCRIPTION
Hello!

Recently, I tried to run PyTorchDemo app on my iPhone (iPhone X, running iOS 14.3 as of today, tried also with 14.2). After running `pod install` and fixing all the problems regarding code signing, I ended up with linker error:
```
ld: in /.../PyTorchDemo/Pods/LibTorch/install/lib/libpytorch_qnnpack.a(8x8-aarch64-neon.S.o), building for iOS, but linking in object file built for macOS, file '/.../PyTorchDemo/Pods/LibTorch/install/lib/libpytorch_qnnpack.a' for architecture arm64
```
(building on Macbook Pro 15" 2017, MacOS 11.1, using Xcode Version 12.3 (12C33))
I don't know, whether this problem could have been tackled otherwise, but I ended updating LibTorch to the latest version `~1.7.0`, which required minor change in code. After that, app was successfully built and started on my iPhone.

One drawback of this solution is the fact that `mobilenet_quantized.pt` torch jit checkpoint failed to load on this version of library. As model quantization was not my main goal, I settled for a mobilenet checkpoint, which I was able to generate using `trace_model.py` from HelloWorld app. This works fine. However, if someone would be as kind as to provide me with analogous python script, which could produce quantized mobilenet checkpoint I would be more than glad to retrace the model and check, that everything works fine on my phone.