### PR TITLE
Remove redundant data conversion

### DIFF
--- a/StreamingASR/StreamingASR/InferenceModule.h
+++ b/StreamingASR/StreamingASR/InferenceModule.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)initWithFileAtPath:(NSString*)filePath
     NS_SWIFT_NAME(init(fileAtPath:))NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
-- (nullable NSString*)recognize:(void*)modelInput NS_SWIFT_NAME(recognize(modelInput));
+- (nullable NSString*)recognize:(const void*)modelInput NS_SWIFT_NAME(recognize(modelInput));
 @end
 
 NS_ASSUME_NONNULL_END

--- a/StreamingASR/StreamingASR/InferenceModule.mm
+++ b/StreamingASR/StreamingASR/InferenceModule.mm
@@ -42,7 +42,7 @@ const int INPUT_SIZE = 3200;
 }
 
 
-- (NSString*)recognize:(void*)modelInput {
+- (NSString*)recognize:(const void*)modelInput {
     try {
         at::Tensor tensorInputs = torch::from_blob((void*)modelInput, {INPUT_SIZE}, at::kFloat);
         

--- a/StreamingASR/StreamingASR/ViewController.swift
+++ b/StreamingASR/StreamingASR/ViewController.swift
@@ -77,17 +77,11 @@ extension ViewController {
                 pcmBufferToBeProcessed += floatArray
             
                 if pcmBufferToBeProcessed.count >= CHUNK_TO_READ * CHUNK_SIZE {
-                    let samples = Array(pcmBufferToBeProcessed[0..<CHUNK_TO_READ * CHUNK_SIZE]) .map { Double($0)/1.0 }
+                    var samples = Array(pcmBufferToBeProcessed[0..<CHUNK_TO_READ * CHUNK_SIZE])
                     pcmBufferToBeProcessed = Array(pcmBufferToBeProcessed[(CHUNK_TO_READ - 1) * CHUNK_SIZE..<pcmBufferToBeProcessed.count])
                     
                     serialQueue.async {
-                        var modelInput = [Float32]()
-                        
-                        for i in 0..<INPUT_SIZE {
-                            modelInput.append(Float32(samples[i]))
-                        }
-                                            
-                        var result = self.module.recognize(&modelInput)
+                        var result = self.module.recognize(&samples)
                         if result!.count > 0 {
                             result = result!.replacingOccurrences(of: "▁", with: "")
                             DispatchQueue.main.async {

--- a/StreamingASR/StreamingASR/ViewController.swift
+++ b/StreamingASR/StreamingASR/ViewController.swift
@@ -77,11 +77,11 @@ extension ViewController {
                 pcmBufferToBeProcessed += floatArray
             
                 if pcmBufferToBeProcessed.count >= CHUNK_TO_READ * CHUNK_SIZE {
-                    var samples = Array(pcmBufferToBeProcessed[0..<CHUNK_TO_READ * CHUNK_SIZE])
+                    let samples = Array(pcmBufferToBeProcessed[0..<CHUNK_TO_READ * CHUNK_SIZE])
                     pcmBufferToBeProcessed = Array(pcmBufferToBeProcessed[(CHUNK_TO_READ - 1) * CHUNK_SIZE..<pcmBufferToBeProcessed.count])
                     
                     serialQueue.async {
-                        var result = self.module.recognize(&samples)
+                        var result = self.module.recognize(samples)
                         if result!.count > 0 {
                             result = result!.replacingOccurrences(of: "▁", with: "")
                             DispatchQueue.main.async {


### PR DESCRIPTION
In streaming ASR example, audio samples areconverted to float64 and back to float32.
This commit removes that.